### PR TITLE
chore: fixed no checks on release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
Added private access token to release please action in order to trigger status checks on release PR's.